### PR TITLE
Respect column position when jumping to tag

### DIFF
--- a/lua/lsp_smag/tags/formatting.lua
+++ b/lua/lsp_smag/tags/formatting.lua
@@ -1,4 +1,5 @@
 local vim = vim
+local lsp = vim.lsp
 local api = vim.api
 
 local M = {}
@@ -21,10 +22,12 @@ function M.lsp_location_to_tag(name, kind, lsp_location)
     local uri = lsp_location.uri or lsp_location.targetUri
     local range = lsp_location.range or lsp_location.targetRange
     local line = range.start.line + 1
+    local bufnr = vim.uri_to_bufnr(uri)
+    local col = lsp.util._get_line_byte_from_position(bufnr, range.start)
 
     return {
         name = name,
-        cmd = tostring(line),
+        cmd = '/\\%' .. tostring(line) .. 'l\\%' .. tostring(col+1) .. 'c/',
         kind = kind .. " ", -- add a gap to the tag name
         filename = get_path(uri),
         user_data = read_line(uri, line)

--- a/lua/lsp_smag/tags/formatting.lua
+++ b/lua/lsp_smag/tags/formatting.lua
@@ -1,5 +1,4 @@
 local vim = vim
-local lsp = vim.lsp
 local api = vim.api
 
 local M = {}


### PR DESCRIPTION
When jumping to declarations etc, include the column number in the target pattern. (Fixes #1)

- We would ideally want to use nvim's `_get_line_byte_from_position` to translate utf-16 position into column bytes, except that this function actually loads buffers unexpectedly.  Instead, we use `vim.str_byteindex` directly in combination with:
       1. If the buffer is already loaded, simply read the line from the buffer
       2. Otherwise, read the line directly from the underlying file (this is the most expensive, though I haven't seen a problem yet)
- Uses `%#c` to target the column _byte_.

Considered alternatives:
1. Some might like the original line-only behavior, perhaps there should be an option, but not sure.
2. We could use a function call as the target of the tag instead of a pattern (similar to nvim's `lsp.util.jump_to_location`) which and only do the utf-16 to utf-8 conversion on the jump, which is potentially cheaper.