### PR TITLE
If LSP doesn't return tags attempt to get tags from the tag file

### DIFF
--- a/doc/lsp_smag.txt
+++ b/doc/lsp_smag.txt
@@ -110,6 +110,13 @@ The following variables can be set to customize the behavior of this plugin.
     [ `declaration`, `implementation`, `definition`, `typeDefinition` ]
     [ `declaration`, `implementation`]
 
+|g:lsp_smag_fallback_tags|
+
+  Whether to fallback to regular tags (e.g. ctags) when the language server
+  didn't return a tag or the LSP client is not running.
+
+  Default: `nil`
+
 
 ==============================================================================
 							  *lsp_smag_todo_list*

--- a/lua/lsp_smag.lua
+++ b/lua/lsp_smag.lua
@@ -40,5 +40,9 @@ function lsp_smag.tagfunc(_, flags, _)
     end
 
     tag_sorting.sort_tags_by_kind(tags)
+    if not next(tags) and vim.g.lsp_smag_fallback_tags then
+        return nil
+    end
+
     return tags
 end


### PR DESCRIPTION
At times I'm working on C projects where I don't have a compile_commands.json, and thus the LSP doesn't fully work on the file. But I do have `tags` file present, and I want `Ctrl-]` to work with them too.
So I've added logic to use the tags file if LSP didn't return any symbol.